### PR TITLE
Fix ping URL path handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Console client for fm-dx-webserver",
   "main": "fm-dx-console.js",
   "scripts": {
-    "start": "node fm-dx-console.js"
+    "start": "node fm-dx-console.js",
+    "test": "node test/tunerinfo.test.js"
   },
   "dependencies": {
     "axios": "^1.8.2",

--- a/test/tunerinfo.test.js
+++ b/test/tunerinfo.test.js
@@ -1,0 +1,36 @@
+const assert = require('assert');
+const Module = require('module');
+
+let calledUrl;
+const axiosStub = {
+  get: async (url) => {
+    calledUrl = url;
+    return { status: 200 };
+  }
+};
+
+const originalLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+  if (request === 'axios') return axiosStub;
+  if (request === 'cheerio') return { load: () => ({}) };
+  return originalLoad(request, parent, isMain);
+};
+
+const { getPingTime } = require('../tunerinfo');
+
+(async () => {
+  await getPingTime('http://example.com/');
+  assert.strictEqual(calledUrl, 'http://example.com/ping');
+
+  await getPingTime('http://example.com/dir');
+  assert.strictEqual(calledUrl, 'http://example.com/dir/ping');
+
+  console.log('All tests passed');
+})()
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => {
+    Module._load = originalLoad;
+  });

--- a/tunerinfo.js
+++ b/tunerinfo.js
@@ -61,7 +61,11 @@ async function getTunerInfo(url) {
 async function getPingTime(url) {
     try {
         const pingUrl = new URL(url);
-        pingUrl.pathname += 'ping'; // Append '/ping' to the existing path
+        // Ensure the base path ends with a single slash before appending 'ping'
+        if (!pingUrl.pathname.endsWith('/')) {
+            pingUrl.pathname += '/';
+        }
+        pingUrl.pathname += 'ping';
         const startTime = Date.now(); // Record start time
 
         // Custom headers (if needed)


### PR DESCRIPTION
## Summary
- ensure `/ping` joins cleanly with any base path
- add unit test verifying URL construction for base paths with and without trailing slash
- expose test script via `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684350c30f34832f90d2df9ab80080e0