### PR TITLE
Add ECC, country and AF fields to RDS displays

### DIFF
--- a/fm-dx-console.js
+++ b/fm-dx-console.js
@@ -346,6 +346,12 @@ const rdsBox = blessed.box({
     border: { type: 'line' },
     style: boxStyle,
     label: boxLabel('RDS'),
+    scrollable: true,
+    alwaysScroll: true,
+    scrollbar: {
+        ch: ' ',
+        inverse: true
+    },
 });
 
 const stationBox = blessed.box({
@@ -524,16 +530,31 @@ function updateRdsBox(data) {
             msshow = "M{grey-fg}S{/grey-fg}";
         }
 
-        rdsBox.setContent(
+        let content =
             `${padStringWithSpaces("PS:", 'green', padLength)}${data.ps.trimStart()}\n` +
-            `${padStringWithSpaces("PI:", 'green', padLength)}${data.pi}\n` +
-            `{center}{bold}Flags{/bold}\n` +
+            `${padStringWithSpaces("PI:", 'green', padLength)}${data.pi}`;
+
+        if (data.ecc) {
+            content += `\n${padStringWithSpaces("ECC:", 'green', padLength)}${data.ecc}`;
+        }
+        const country = data.country_name || data.country_iso;
+        if (country) {
+            content += `\n${padStringWithSpaces("Country:", 'green', padLength)}${country}`;
+        }
+
+        content +=
+            `\n{center}{bold}Flags{/bold}\n` +
             `${data.tp ? "TP" : "{grey-fg}TP{/grey-fg}"} ` +
             `${data.ta ? "TA" : "{grey-fg}TA{/grey-fg}"} ` +
             `${msshow}\n` +
             `PTY: ${data.pty !== undefined ? data.pty : 0}/` +
-            `${europe_programmes[data.pty !== undefined ? data.pty : 0] || 'None'}{/center}`
-        );
+            `${europe_programmes[data.pty !== undefined ? data.pty : 0] || 'None'}{/center}`;
+
+        if (Array.isArray(data.af) && data.af.length) {
+            content += `\n${padStringWithSpaces("AF:", 'green', padLength)}${data.af.join(',')}`;
+        }
+
+        rdsBox.setContent(content);
     } else {
         rdsBox.setContent('');
     }

--- a/renderer.js
+++ b/renderer.js
@@ -96,7 +96,19 @@ function updateUI() {
   const ptyName = europe_programmes[ptyNum] || 'None';
   const ps = currentData.ps ? currentData.ps : '';
   const pi = currentData.pi || '';
-  rds.textContent = `PS: ${ps}  PI: ${pi}\n${flags}\nPTY: ${ptyNum}/${ptyName}`;
+  let rdsText = `PS: ${ps}\nPI: ${pi}`;
+  if (currentData.ecc) {
+    rdsText += `\nECC: ${currentData.ecc}`;
+  }
+  const country = currentData.country_name || currentData.country_iso;
+  if (country) {
+    rdsText += `\nCountry: ${country}`;
+  }
+  rdsText += `\n${flags}\nPTY: ${ptyNum}/${ptyName}`;
+  if (Array.isArray(currentData.af) && currentData.af.length) {
+    rdsText += `\nAF: ${currentData.af.join(',')}`;
+  }
+  rds.textContent = rdsText;
 
   const rt = document.getElementById('rt-info');
   const line1 = currentData.rt0 ? currentData.rt0 : '\u00a0';


### PR DESCRIPTION
## Summary
- show ECC, country and AF in console RDS info
- make console RDS box scrollable
- display the same fields in Electron renderer

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843fb5c0504832fa4ab80129d48dc74