### PR TITLE
Fix RDS PS display when PS missing

### DIFF
--- a/fm-dx-console.js
+++ b/fm-dx-console.js
@@ -524,8 +524,10 @@ function updateRdsBox(data) {
             msshow = "M{grey-fg}S{/grey-fg}";
         }
 
+        const ps = data.ps ? data.ps.trimStart() : '';
+
         rdsBox.setContent(
-            `${padStringWithSpaces("PS:", 'green', padLength)}${data.ps.trimStart()}\n` +
+            `${padStringWithSpaces("PS:", 'green', padLength)}${ps}\n` +
             `${padStringWithSpaces("PI:", 'green', padLength)}${data.pi}\n` +
             `{center}{bold}Flags{/bold}\n` +
             `${data.tp ? "TP" : "{grey-fg}TP{/grey-fg}"} ` +


### PR DESCRIPTION
## Summary
- handle missing `ps` field in RDS data

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843fb66dc58832f9fa3f0ce048ee285