### PR TITLE
Add RDS DI fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ the Station section always lists its field names (Name, Location, etc.) even if
 data is missing. Server details show the tuner name followed by the description
 on separate lines. RDS information lists the PS and PI codes along with
 flags and the Programme Type shown as `number/name` (displaying `0/None` when
-no PTY is available). The frequency field accepts only numeric input and the
+no PTY is available). If Decoder Information bits are present, the panel also
+shows whether Dynamic PTY, Artificial Head or Compression are enabled and if
+the broadcast is stereo. The frequency field accepts only numeric input and the
 shortcut **t** focuses it without inserting the letter. Launch it with:
 
 The status section shows the current user count, ping time and whether audio is

--- a/fm-dx-console.js
+++ b/fm-dx-console.js
@@ -550,6 +550,14 @@ function updateRdsBox(data) {
             `PTY: ${data.pty !== undefined ? data.pty : 0}/` +
             `${europe_programmes[data.pty !== undefined ? data.pty : 0] || 'None'}{/center}`;
 
+        if (data.dynamic_pty !== undefined || data.artificial_head !== undefined || data.compressed !== undefined) {
+            content += `\nDI: ` +
+                `DP:${data.dynamic_pty ? 'On' : 'Off'} ` +
+                `AH:${data.artificial_head ? 'On' : 'Off'} ` +
+                `C:${data.compressed ? 'On' : 'Off'} ` +
+                `Stereo:${data.st ? 'Yes' : 'No'}`;
+        }
+
         if (Array.isArray(data.af) && data.af.length) {
             content += `\n${padStringWithSpaces("AF:", 'green', padLength)}${data.af.join(',')}`;
         }

--- a/renderer.js
+++ b/renderer.js
@@ -105,6 +105,18 @@ function updateUI() {
     rdsText += `\nCountry: ${country}`;
   }
   rdsText += `\n${flags}\nPTY: ${ptyNum}/${ptyName}`;
+  if (
+    currentData.dynamic_pty !== undefined ||
+    currentData.artificial_head !== undefined ||
+    currentData.compressed !== undefined
+  ) {
+    rdsText +=
+      `\nDI: ` +
+      `DP:${currentData.dynamic_pty ? 'On' : 'Off'} ` +
+      `AH:${currentData.artificial_head ? 'On' : 'Off'} ` +
+      `C:${currentData.compressed ? 'On' : 'Off'} ` +
+      `Stereo:${currentData.st ? 'Yes' : 'No'}`;
+  }
   if (Array.isArray(currentData.af) && currentData.af.length) {
     rdsText += `\nAF: ${currentData.af.join(',')}`;
   }


### PR DESCRIPTION
## Summary
- display optional RDS decoder information bits in console and Electron UI
- note the additional Decoder Information display in the README

## Testing
- `npm test` *(fails: Missing script)*
- `node fm-dx-console.js --help`

------
https://chatgpt.com/codex/tasks/task_e_6843fd5d2494832f8bfddb60d25550d4