### PR TITLE
Show RDS error reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ the Station section always lists its field names (Name, Location, etc.) even if
 data is missing. Server details show the tuner name followed by the description
 on separate lines. RDS information lists the PS and PI codes along with
 flags and the Programme Type shown as `number/name` (displaying `0/None` when
-no PTY is available). The frequency field accepts only numeric input and the
+no PTY is available). If Decoder Information bits are present, the panel also
+shows whether Dynamic PTY, Artificial Head or Compression are enabled and if
+the broadcast is stereo. Characters in the PS and RadioText turn grey when
+errors are reported. The frequency field accepts only numeric input and the
 shortcut **t** focuses it without inserting the letter. Launch it with:
 
 The status section shows the current user count, ping time and whether audio is

--- a/fm-dx-console.js
+++ b/fm-dx-console.js
@@ -254,6 +254,24 @@ function padStringWithSpaces(text, color = 'green', totalLength) {
     return ' ' + `{${color}-fg}` + text + `{/${color}-fg}` + ' '.repeat(spacesToAdd);
 }
 
+/**
+ * Apply grey markup to characters with non-zero error counts
+ */
+function processStringWithErrors(str, errors) {
+    if (!str) return '';
+    const errArr = (errors || '').split(',').map(e => parseInt(e, 10) || 0);
+    let out = '';
+    for (let i = 0; i < str.length; i++) {
+        const ch = str[i];
+        if (errArr[i] > 0) {
+            out += `{grey-fg}${ch}{/grey-fg}`;
+        } else {
+            out += ch;
+        }
+    }
+    return out;
+}
+
 /** Returns a label string with bold, colored style */
 function boxLabel(label) {
     return `{white-fg}{blue-bg}{bold}${label}{/bold}{/blue-bg}{/white-fg}`;
@@ -530,8 +548,9 @@ function updateRdsBox(data) {
             msshow = "M{grey-fg}S{/grey-fg}";
         }
 
+        const psDisplay = processStringWithErrors(data.ps.trimStart(), data.ps_errors);
         let content =
-            `${padStringWithSpaces("PS:", 'green', padLength)}${data.ps.trimStart()}\n` +
+            `${padStringWithSpaces("PS:", 'green', padLength)}${psDisplay}\n` +
             `${padStringWithSpaces("PI:", 'green', padLength)}${data.pi}`;
 
         if (data.ecc) {
@@ -550,6 +569,14 @@ function updateRdsBox(data) {
             `PTY: ${data.pty !== undefined ? data.pty : 0}/` +
             `${europe_programmes[data.pty !== undefined ? data.pty : 0] || 'None'}{/center}`;
 
+        if (data.dynamic_pty !== undefined || data.artificial_head !== undefined || data.compressed !== undefined) {
+            content += `\nDI: ` +
+                `DP:${data.dynamic_pty ? 'On' : 'Off'} ` +
+                `AH:${data.artificial_head ? 'On' : 'Off'} ` +
+                `C:${data.compressed ? 'On' : 'Off'} ` +
+                `Stereo:${data.st ? 'Yes' : 'No'}`;
+        }
+
         if (Array.isArray(data.af) && data.af.length) {
             content += `\n${padStringWithSpaces("AF:", 'green', padLength)}${data.af.join(',')}`;
         }
@@ -562,8 +589,8 @@ function updateRdsBox(data) {
 
 function updateRTBox(data) {
     if (!rtBox || !data) return;
-    const line1 = data.rt0 ? data.rt0.trim() : '\xA0';
-    const line2 = data.rt1 ? data.rt1.trim() : '\xA0';
+    const line1 = processStringWithErrors(data.rt0 ? data.rt0.trim() : '\xA0', data.rt0_errors);
+    const line2 = processStringWithErrors(data.rt1 ? data.rt1.trim() : '\xA0', data.rt1_errors);
     rtBox.setContent(
         `{center}${line1}{/center}\n` +
         `{center}${line2}{/center}`


### PR DESCRIPTION
## Summary
- display PS/RT error reliability using grey text
- support HTML rendering for decoder info and error highlighting
- mention the grey PS and RadioText in the README

## Testing
- `npm test` *(fails: Missing script)*
- `node fm-dx-console.js --help`


------
https://chatgpt.com/codex/tasks/task_e_6843fd5d2494832f8bfddb60d25550d4