### PR TITLE
Add server-side spectrum graph support

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -8,5 +8,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onWsData: (cb) => ipcRenderer.on('ws-data', (_e, data) => cb(data)),
   sendCommand: (cmd) => ipcRenderer.send('ws-send', cmd),
   setUrl: (url) => ipcRenderer.invoke('set-url', url),
-  onAudioStopped: (cb) => ipcRenderer.on('audio-stopped', cb)
+  onAudioStopped: (cb) => ipcRenderer.on('audio-stopped', cb),
+  getSpectrumData: () => ipcRenderer.invoke('get-spectrum-data'),
+  startSpectrumScan: () => ipcRenderer.invoke('start-spectrum-scan')
 });


### PR DESCRIPTION
## Summary
- hook up websocket for Spectrum Graph plugin
- expose IPC handlers to trigger scan and fetch spectrum data
- update renderer to query plugin endpoint

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68440c108300832f91cadca438b6078a