### PR TITLE
Fix spectrum scan and antenna switch reload

### DIFF
--- a/main.js
+++ b/main.js
@@ -131,7 +131,7 @@ function createWindow() {
 
   ipcMain.handle('start-spectrum-scan', () => {
     if (pluginWs && pluginWs.readyState === WebSocket.OPEN) {
-      const msg = JSON.stringify({ type: 'spectrum-graph', value: { status: 'scan' } });
+      const msg = JSON.stringify({ type: 'spectrum-graph', action: 'scan' });
       pluginWs.send(msg);
     }
   });

--- a/renderer.js
+++ b/renderer.js
@@ -233,6 +233,7 @@ document.getElementById('ant-btn').onclick = () => {
     let newAnt = parseInt(currentData.ant) + 1;
     if (antNames.length && newAnt >= antNames.length) newAnt = 0;
     sendCmd(`Z${newAnt}`);
+    fetchSpectrumData();
   }
 };
 


### PR DESCRIPTION
## Summary
- trigger server-side spectrum scanning by using `action: 'scan'`
- refresh spectrum graph when cycling antennas

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68441732c46c832f8133882833fbac5c