### PR TITLE
Add plugin header for websocket

### DIFF
--- a/main.js
+++ b/main.js
@@ -66,7 +66,12 @@ function createWindow() {
     if (pluginWs) pluginWs.close();
     if (!url) return;
     const wsAddr = `${formatWebSocketURL(url)}/data_plugins`;
-    const opts = { headers: { 'User-Agent': `${userAgent} (plugin)` } };
+    const opts = {
+      headers: {
+        'User-Agent': `${userAgent} (plugin)`,
+        'X-Plugin-Name': 'SpectrumGraphPlugin'
+      }
+    };
     pluginWs = new WebSocket(wsAddr, opts);
   }
 


### PR DESCRIPTION
## Summary
- ensure plugin websocket connection sends plugin name header

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_684434b7d50c832fb839068ba5b99527