### PR TITLE
Add tabs and frequency picker to Android client

### DIFF
--- a/app/android/app/src/main/java/com/fmdx/android/MainActivity.kt
+++ b/app/android/app/src/main/java/com/fmdx/android/MainActivity.kt
@@ -8,15 +8,19 @@ import androidx.activity.viewModels
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.annotation.StringRes
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -63,6 +67,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.draw.clip
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.fmdx.android.model.SignalUnit
 import com.fmdx.android.model.SpectrumPoint
@@ -158,13 +163,17 @@ private fun FmDxApp(
                     }
                 },
                 actions = {
-                    IconButton(onClick = onToggleAudio) {
-                        val playing = state.audioPlaying
-                        val icon = if (playing) Icons.Filled.Pause else Icons.Filled.PlayArrow
-                        Icon(
-                            imageVector = icon,
-                            contentDescription = if (playing) stringResource(id = R.string.stop_audio) else stringResource(id = R.string.play_audio)
-                        )
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        ConnectionStatusIndicator(isConnected = state.isConnected)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        IconButton(onClick = onToggleAudio) {
+                            val playing = state.audioPlaying
+                            val icon = if (playing) Icons.Filled.Pause else Icons.Filled.PlayArrow
+                            Icon(
+                                imageVector = icon,
+                                contentDescription = if (playing) stringResource(id = R.string.stop_audio) else stringResource(id = R.string.play_audio)
+                            )
+                        }
                     }
                 }
             )
@@ -209,6 +218,34 @@ private data class SectionTab(
     @StringRes val titleRes: Int,
     val content: @Composable () -> Unit
 )
+
+@Composable
+private fun ConnectionStatusIndicator(isConnected: Boolean) {
+    val label = if (isConnected) {
+        stringResource(id = R.string.connected)
+    } else {
+        stringResource(id = R.string.disconnected)
+    }
+    val indicatorColor = if (isConnected) {
+        MaterialTheme.colorScheme.tertiary
+    } else {
+        MaterialTheme.colorScheme.error
+    }
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier = Modifier
+                .size(10.dp)
+                .clip(CircleShape)
+                .background(indicatorColor)
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
 
 @Composable
 private fun ServerSection(

--- a/app/android/app/src/main/java/com/fmdx/android/MainActivity.kt
+++ b/app/android/app/src/main/java/com/fmdx/android/MainActivity.kt
@@ -250,28 +250,34 @@ private fun FrequencySection(
     onTuneDirect: (Double) -> Unit,
     onRefresh: () -> Unit
 ) {
-    val minFreq = 8_750
-    val maxFreq = 10_800
+    val minFreqTenth = 875
+    val maxFreqTenth = 1080
     val displayValues = remember {
-        (minFreq..maxFreq).map { freqValue ->
-            String.format(Locale.getDefault(), "%.2f", freqValue / 100.0)
+        (minFreqTenth..maxFreqTenth).map { freqValue ->
+            String.format(Locale.getDefault(), "%.1f", freqValue / 10.0)
         }.toTypedArray()
     }
-    val currentIndex = state.tunerState?.freqMHz?.times(100)?.roundToInt()?.minus(minFreq)
-    var selectedIndex by rememberSaveable { mutableIntStateOf(currentIndex?.coerceIn(0, maxFreq - minFreq) ?: 0) }
+    val rangeSize = maxFreqTenth - minFreqTenth
+    val currentIndex = state.tunerState?.freqMHz?.times(10)?.roundToInt()?.minus(minFreqTenth)
+    var selectedIndex by rememberSaveable { mutableIntStateOf(currentIndex?.coerceIn(0, rangeSize) ?: 0) }
     LaunchedEffect(currentIndex) {
         currentIndex?.let {
-            val bounded = it.coerceIn(0, maxFreq - minFreq)
+            val bounded = it.coerceIn(0, rangeSize)
             if (bounded != selectedIndex) {
                 selectedIndex = bounded
             }
         }
     }
-    val selectedFrequency = (minFreq + selectedIndex) / 100.0
+    val selectedFrequency = (minFreqTenth + selectedIndex) / 10.0
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
             Text(text = stringResource(id = R.string.frequency), style = MaterialTheme.typography.titleLarge)
-            Text(text = stringResource(id = R.string.selected_frequency_label, String.format(Locale.getDefault(), "%.2f", selectedFrequency)))
+            Text(
+                text = stringResource(
+                    id = R.string.selected_frequency_label,
+                    String.format(Locale.getDefault(), "%.1f", selectedFrequency)
+                )
+            )
             AndroidView(
                 modifier = Modifier.fillMaxWidth(),
                 factory = { context ->
@@ -279,7 +285,7 @@ private fun FrequencySection(
                         descendantFocusability = NumberPicker.FOCUS_BLOCK_DESCENDANTS
                         wrapSelectorWheel = false
                         minValue = 0
-                        maxValue = displayValues.size - 1
+                        maxValue = rangeSize
                         value = selectedIndex
                         displayedValues = displayValues
                         setOnValueChangedListener { _, _, newVal ->

--- a/app/android/app/src/main/java/com/fmdx/android/MainActivity.kt
+++ b/app/android/app/src/main/java/com/fmdx/android/MainActivity.kt
@@ -250,9 +250,13 @@ private fun FrequencySection(
     onTuneDirect: (Double) -> Unit,
     onRefresh: () -> Unit
 ) {
-    val minFreq = 875
-    val maxFreq = 1080
-    val displayValues = remember { (minFreq..maxFreq).map { String.format(Locale.getDefault(), "%.2f", it / 100.0) }.toTypedArray() }
+    val minFreq = 8_750
+    val maxFreq = 10_800
+    val displayValues = remember {
+        (minFreq..maxFreq).map { freqValue ->
+            String.format(Locale.getDefault(), "%.2f", freqValue / 100.0)
+        }.toTypedArray()
+    }
     val currentIndex = state.tunerState?.freqMHz?.times(100)?.roundToInt()?.minus(minFreq)
     var selectedIndex by rememberSaveable { mutableIntStateOf(currentIndex?.coerceIn(0, maxFreq - minFreq) ?: 0) }
     LaunchedEffect(currentIndex) {

--- a/app/android/app/src/main/java/com/fmdx/android/audio/WebSocketAudioPlayer.kt
+++ b/app/android/app/src/main/java/com/fmdx/android/audio/WebSocketAudioPlayer.kt
@@ -12,7 +12,7 @@ import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DataSpec
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
-import com.fmdx.android.data.formatWebSocketUrl
+import com.fmdx.android.data.buildWebSocketUrl
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okhttp3.OkHttpClient
@@ -41,7 +41,7 @@ class WebSocketAudioPlayer(
     ) {
         mutex.withLock {
             stopLocked()
-            val wsUrl = "${formatWebSocketUrl(baseUrl)}/audio"
+            val wsUrl = buildWebSocketUrl(baseUrl, "audio")
             val factory = DataSource.Factory {
                 WebSocketStreamDataSource(client, wsUrl, userAgent, onError).also {
                     currentDataSource = it

--- a/app/android/app/src/main/res/values/strings.xml
+++ b/app/android/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="toggle_eq">Toggle EQ</string>
     <string name="antenna_label">Antenna: %1$s</string>
     <string name="audio_playing">Audio playing</string>
+    <string name="connected">Connected</string>
     <string name="disconnected">Disconnected</string>
     <string name="signal_label">Signal: %1$s</string>
     <string name="ping_label">Ping: %1$s</string>

--- a/app/android/app/src/main/res/values/strings.xml
+++ b/app/android/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="refresh_spectrum">Refresh Spectrum</string>
     <string name="server">Server</string>
     <string name="frequency">Frequency</string>
+    <string name="selected_frequency_label">Selected frequency: %1$s MHz</string>
     <string name="status">Status</string>
     <string name="controls">Controls</string>
     <string name="rds">RDS</string>


### PR DESCRIPTION
## Summary
- replace the single scrolling Android layout with Material tabs so each major section renders independently
- add a NumberPicker-based frequency selector with a saved selection label and remove the ad-hoc 0.001 MHz step buttons
- persist the sanitized server URL in shared preferences so the last server is restored on launch

## Testing
- Attempted `./gradlew lint --console=plain` *(terminated due to environment hang)*

------
https://chatgpt.com/codex/tasks/task_e_68e03af042cc832f945eb1e8499b22ee