### PR TITLE
Improve Android connection status feedback

### DIFF
--- a/app/android/app/src/main/res/values/strings.xml
+++ b/app/android/app/src/main/res/values/strings.xml
@@ -20,13 +20,15 @@
     <string name="signal_unit">Signal unit</string>
     <string name="toggle_ims">Toggle iMS</string>
     <string name="toggle_eq">Toggle EQ</string>
-    <string name="antenna_label">Antenna: %1$s</string>
     <string name="audio_playing">Audio playing</string>
     <string name="connected">Connected</string>
     <string name="disconnected">Disconnected</string>
+    <string name="connecting">Connecting</string>
     <string name="signal_label">Signal: %1$s</string>
     <string name="ping_label">Ping: %1$s</string>
     <string name="users_label">Users: %1$s</string>
     <string name="audio_label">Audio: %1$s</string>
     <string name="spectrum_unavailable">Spectrum data unavailable</string>
+    <string name="antenna_switch">Cycle antenna</string>
+    <string name="antenna_current">Current: %1$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- surface connecting/connected states in the Android app with a richer status chip, progress indicator, and contextual status text
- ensure command buttons are disabled until a session is active and clarify the antenna switch by separating its label from the action
- propagate connection state into the view-model so audio toggles prompt a connection attempt and user messages stay in sync

## Testing
- `./gradlew --console=plain assembleDebug` *(fails: Android SDK is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0da21bbe0832f8f9af0f106af0eba